### PR TITLE
Fix error of plugins undefined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ module.exports = (config, env, helpers, params = defaultParams) => {
 
   const postCssLoaders = helpers.getLoadersByName(config, "postcss-loader");
   postCssLoaders.forEach(({ loader }) => {
-    const plugins = loader.options.plugins;
+    const plugins = loader.options.postcssOptions.plugins;
 
     // Add tailwind css at the top.
     plugins.unshift(require("tailwindcss"));


### PR DESCRIPTION
In latest version of postcss and Tailwind, we are getting a error where "unshift of undefined" is thrown.
This fixes the error.